### PR TITLE
Fixes for test e-mail

### DIFF
--- a/src/main/java/hudson/tasks/Mailer.java
+++ b/src/main/java/hudson/tasks/Mailer.java
@@ -597,8 +597,8 @@ public class Mailer extends Notifier implements SimpleBuildStep {
          */
         @RequirePOST
         public FormValidation doSendTestMail(
-                @QueryParameter String smtpServer, @QueryParameter String adminAddress, @QueryParameter boolean useSMTPAuth,
-                @QueryParameter String smtpAuthUserName, @QueryParameter Secret smtpAuthPasswordSecret,
+                @QueryParameter String smtpHost, @QueryParameter String adminAddress, @QueryParameter boolean authentication,
+                @QueryParameter String username, @QueryParameter Secret password,
                 @QueryParameter boolean useSsl, @QueryParameter String smtpPort, @QueryParameter String charset,
                 @QueryParameter String sendTestMailTo) throws IOException, ServletException, InterruptedException {
             try {
@@ -610,12 +610,12 @@ public class Mailer extends Notifier implements SimpleBuildStep {
 
                 jenkins.checkPermission(Jenkins.ADMINISTER);
                 
-                if (!useSMTPAuth) {
-                    smtpAuthUserName = null;
-                    smtpAuthPasswordSecret = null;
+                if (!authentication) {
+                    username = null;
+                    password = null;
                 }
                 
-                MimeMessage msg = new MimeMessage(createSession(smtpServer, smtpPort, useSsl, smtpAuthUserName, smtpAuthPasswordSecret));
+                MimeMessage msg = new MimeMessage(createSession(smtpHost, smtpPort, useSsl, username, password));
                 msg.setSubject(Messages.Mailer_TestMail_Subject(testEmailCount.incrementAndGet()), charset);
                 msg.setText(Messages.Mailer_TestMail_Content(testEmailCount.get(), jenkins.getDisplayName()), charset);
                 msg.setFrom(stringToAddress(adminAddress, charset));

--- a/src/main/resources/hudson/tasks/Mailer/global.jelly
+++ b/src/main/resources/hudson/tasks/Mailer/global.jelly
@@ -52,7 +52,7 @@ THE SOFTWARE.
       <f:entry title="${%Test e-mail recipient}">
           <f:textbox name="sendTestMailTo"/>
       </f:entry>
-      <f:validateButton method="sendTestMail" title="${%Test configuration}" with="sendTestMailTo,smtpServer,adminAddress,useSMTPAuth,smtpAuthUserName,smtpAuthPasswordSecret,useSsl,smtpPort,charset" />
+      <f:validateButton method="sendTestMail" title="${%Test configuration}" with="sendTestMailTo,smtpHost,adminAddress,authentication,username,password,useSsl,smtpPort,charset" />
     </f:optionalBlock>
   </f:section>
 </j:jelly>


### PR DESCRIPTION
Send test mail feature was broken because field names were changed. This PR is to match the fields names with validateButton attributes. 